### PR TITLE
Fix CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,14 @@ include $(KOHERON_SERVER_MK)
 # -------------------------------------------------------------------------------------
 
 $(PY2_VENV): requirements.txt
-	test -d $(PY2_VENV) || (virtualenv $(PY2_VENV) && $(PY2_VENV)/bin/pip install -r requirements.txt)
+	test -d $(PY2_VENV) || (virtualenv $(PY2_VENV) && \
+	                        $(PY2_VENV)/bin/pip install -r requirements.txt && \
+	                        $(PY2_VENV)/bin/pip install numpy==1.11.1 pytest)
 
 $(PY3_VENV): requirements.txt
-	test -d $(PY3_VENV) || (virtualenv -p python3 $(PY3_VENV) && $(PY3_VENV)/bin/pip3 install -r requirements.txt)
+	test -d $(PY3_VENV) || (virtualenv -p python3 $(PY3_VENV) && \
+	                        $(PY3_VENV)/bin/pip3 install -r requirements.txt && \
+	                        $(PY3_VENV)/bin/pip3 install numpy==1.11.1 pytest)
 
 test: $(PY2_VENV) $(PY3_VENV) $(TESTS_PY)
 	PYTEST_UNIXSOCK=/tmp/kserver_local.sock $(PY2_VENV)/bin/python -m pytest -v $(TESTS_PY)


### PR DESCRIPTION
Numpy and pytest have been removed from requirements.txt (https://github.com/Koheron/koheron-python/commit/e9cd291bd60701cd7e8ba49fc38ccd106cd6cd65) so we need to install them separately for testing.